### PR TITLE
feat: Allow censoring of Eden transactions

### DIFF
--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -127,6 +127,7 @@ var (
 		utils.MinerNoVerfiyFlag,
 		utils.MinerMaxFlashbotWorkers,
 		utils.MinerMaxEdenWorkers,
+		utils.MinerCensorEden,
 		utils.MinerEdenRewardPerBlock,
 		utils.NATFlag,
 		utils.NoDiscoverFlag,

--- a/cmd/geth/usage.go
+++ b/cmd/geth/usage.go
@@ -188,6 +188,7 @@ var AppHelpFlagGroups = []flags.FlagGroup{
 			utils.MinerNoVerfiyFlag,
 			utils.MinerMaxFlashbotWorkers,
 			utils.MinerMaxEdenWorkers,
+			utils.MinerCensorEden,
 			utils.MinerEdenRewardPerBlock,
 		},
 	},

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -473,7 +473,6 @@ var (
 	MinerCensorEden = cli.BoolFlag{
 		Name: "miner.censoreden",
 		Usage: "eden - flag to censor eden transactions in flashbots blocks to remain eden compliant",
-		Value: true,
 	}
 	MinerEdenRewardPerBlock = cli.StringFlag{
 		Name:  "miner.edenrewardperblock",

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -470,6 +470,11 @@ var (
 		Usage: "eden - The maximum amount of bundles to merge. The miner will run this many workers in parallel to calculate if the full block is more profitable with these additional bundles.",
 		Value: 3,
 	}
+	MinerCensorEden = cli.BoolFlag{
+		Name: "miner.censoreden",
+		Usage: "eden - flag to censor eden transactions in flashbots blocks to remain eden compliant",
+		Value: true,
+	}
 	MinerEdenRewardPerBlock = cli.StringFlag{
 		Name:  "miner.edenrewardperblock",
 		Usage: "eden - The expected amount of eden rewarded per block mined. ",

--- a/miner/miner.go
+++ b/miner/miner.go
@@ -54,6 +54,7 @@ type Config struct {
 	MaxFlashbotWorkers int
 	MaxEdenWorkers     int
 	EdenRewardPerBlock string
+	CensorEden         bool
 }
 
 // Miner creates blocks and searches for proof-of-work values.

--- a/miner/multi_worker.go
+++ b/miner/multi_worker.go
@@ -91,6 +91,7 @@ func newMultiWorker(config *Config, chainConfig *params.ChainConfig, engine cons
 	regularWorker := newWorker(config, chainConfig, engine, eth, mux, isLocalBlock, init, &flashbotsData{
 		isFlashbots: false,
 		isEden:      false,
+		censorEden:  config.CensorEden,
 		queue:       queue,
 	})
 
@@ -101,6 +102,7 @@ func newMultiWorker(config *Config, chainConfig *params.ChainConfig, engine cons
 			newWorker(config, chainConfig, engine, eth, mux, isLocalBlock, init, &flashbotsData{
 				isFlashbots:      true,
 				isEden:           false,
+				censorEden:       config.CensorEden,
 				queue:            queue,
 				maxMergedBundles: i,
 			}))
@@ -110,6 +112,7 @@ func newMultiWorker(config *Config, chainConfig *params.ChainConfig, engine cons
 			newWorker(config, chainConfig, engine, eth, mux, isLocalBlock, init, &flashbotsData{
 				isFlashbots:        true,
 				isEden:             true,
+				censorEden:         false,
 				queue:              queue,
 				maxMergedBundles:   i,
 				edenRewardPerBlock: config.EdenRewardPerBlock,
@@ -126,6 +129,7 @@ func newMultiWorker(config *Config, chainConfig *params.ChainConfig, engine cons
 type flashbotsData struct {
 	isFlashbots        bool
 	isEden             bool
+	censorEden         bool
 	queue              chan *task
 	maxMergedBundles   int
 	edenRewardPerBlock string

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -561,9 +561,9 @@ func (w *worker) mainLoop() {
 						continue
 					}
 					w.eden.SetTransactionsStake(parentState, txs)
-					txset = types.NewTransactionsByStakeAndNonce(w.current.signer, txs, w.current.header.BaseFee)
+					txset = types.NewTransactionsByStakeAndNonce(w.current.signer, txs, w.current.header.BaseFee, w.flashbots.censorEden)
 				} else {
-					txset = types.NewTransactionsByPriceAndNonce(w.current.signer, txs, w.current.header.BaseFee)
+					txset = types.NewTransactionsByPriceAndNonce(w.current.signer, txs, w.current.header.BaseFee, false)
 				}
 				tcount := w.current.tcount
 				w.commitTransactions(txset, coinbase, nil)

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -563,7 +563,7 @@ func (w *worker) mainLoop() {
 					w.eden.SetTransactionsStake(parentState, txs)
 					txset = types.NewTransactionsByStakeAndNonce(w.current.signer, txs, w.current.header.BaseFee, w.flashbots.censorEden)
 				} else {
-					txset = types.NewTransactionsByPriceAndNonce(w.current.signer, txs, w.current.header.BaseFee, false)
+					txset = types.NewTransactionsByPriceAndNonce(w.current.signer, txs, w.current.header.BaseFee)
 				}
 				tcount := w.current.tcount
 				w.commitTransactions(txset, coinbase, nil)


### PR DESCRIPTION
Miners don't want to get slashed by Eden for submitting non-Eden blocks. There are two primary ways to avoid slashing - either mine through a different Coinbase (inconvenient, a hassle), or mine Eden-compliant blocks. 

"But Eden compliant blocks are less profitable!" you say. Well, not anymore. If miners "forget" any Eden transaction they receive, a standard flashbots or vanilla geth block is Eden compliant! And there is no way for the Eden team to be sure that you are cheating; a miner running greeden-geth's behavior is indistinguishable from an "honest" miner running eden-geth, but simply not receiving the Eden transactions in time. 

So you can double dip! Claim the full MEV rewards, and also the EDEN rewards! Best of both worlds!

